### PR TITLE
[Fix] #49 : 서류 현황 조회 API 즐겨찾기 대상으로 수정

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -168,7 +168,6 @@ CREATE TABLE user_policies (
     first_payment_date DATE NULL,
     monthly_amount INT NULL, 
     total_amount INT NULL,
-    status VARCHAR(20) NOT NULL DEFAULT '요건확인' COMMENT '"요건확인", "서류 수집/업로드", "제출 준비", "제출 완료/결과"',
     CONSTRAINT fk_user_policies_user_id FOREIGN KEY (user_id)
         REFERENCES users (user_id)
         ON DELETE CASCADE,
@@ -197,7 +196,6 @@ CREATE TABLE user_loans (
 	loan_principal	BIGINT	NOT NULL,
 	next_repay_date	DATE	NOT NULL,
 	loan_organization	VARCHAR(255)	NOT NULL,
-    status VARCHAR(20) NOT NULL DEFAULT '요건확인' COMMENT '"요건확인", "서류 수집/업로드", "제출 준비", "제출 완료/결과"',
 	CONSTRAINT fk_user_loans_user_id FOREIGN KEY (user_id)
 		REFERENCES users (user_id)
 		ON DELETE CASCADE,
@@ -231,6 +229,7 @@ CREATE TABLE user_policy_bookmarks (
 	bookmark_policy_id	BIGINT	AUTO_INCREMENT PRIMARY KEY,
 	user_id	BIGINT	NOT NULL,
 	policy_id	VARCHAR(255)	NOT NULL,
+    status VARCHAR(20) NOT NULL DEFAULT '요건확인' COMMENT '"요건확인", "서류 수집/업로드", "제출 준비", "제출 완료/결과"',
 	CONSTRAINT fk_user_policy_bookmarks_user_id FOREIGN KEY (user_id)
 		REFERENCES users (user_id)
 		ON DELETE CASCADE,
@@ -243,7 +242,8 @@ CREATE TABLE user_loan_bookmarks (
 	bookmark_loan_id	BIGINT	AUTO_INCREMENT PRIMARY KEY,
 	user_id	BIGINT	NOT NULL,
 	loan_id	BIGINT	NOT NULL,
-	CONSTRAINT fk_user_loan_bookmarks_user_id FOREIGN KEY (user_id)
+    status VARCHAR(20) NOT NULL DEFAULT '요건확인' COMMENT '"요건확인", "서류 수집/업로드", "제출 준비", "제출 완료/결과"',
+CONSTRAINT fk_user_loan_bookmarks_user_id FOREIGN KEY (user_id)
 		REFERENCES users (user_id)
 		ON DELETE CASCADE,
 	CONSTRAINT fk_user_loan_bookmarks_loan_id FOREIGN KEY (loan_id)

--- a/src/main/resources/com/gagechaeum/backend/application/mapper/ApplicationMapper.xml
+++ b/src/main/resources/com/gagechaeum/backend/application/mapper/ApplicationMapper.xml
@@ -14,61 +14,61 @@
     </resultMap>
 
     <select id="findApplicationsByUserId" parameterType="long" resultMap="ApplicationResultMap">
-        -- 사용자가 신청한 정책 현황 조회
+        -- 사용자가 즐겨찾기한 정책 현황 조회
         SELECT
-            CONCAT('policy_', up.user_policy_id) AS applicationId,
-            up.status AS processStage,
+            CONCAT('policy_', upb.bookmark_policy_id) AS applicationId,
+            upb.status AS processStage,
             '정책' AS productType,
             p.policy_name AS productName,
             p.supervising_organization_name AS providerName,
             (SELECT COUNT(DISTINCT rd.document_id)
              FROM required_documents rd
-                      JOIN user_documents ud ON rd.document_id = ud.document_id
-             WHERE rd.policy_id = up.policy_id AND ud.user_id = up.user_id) AS completedDocsCount,
+                      JOIN user_documents ud ON rd.document_id = ud.document_id AND ud.user_id = upb.user_id
+             WHERE rd.policy_id = upb.policy_id) AS completedDocsCount,
             (SELECT COUNT(*)
              FROM required_documents
-             WHERE policy_id = up.policy_id) AS totalDocsCount
+             WHERE policy_id = upb.policy_id) AS totalDocsCount
         FROM
-            user_policies up
+            user_policy_bookmarks upb
                 JOIN
-            policies p ON up.policy_id = p.policy_id
+            policies p ON upb.policy_id = p.policy_id
         WHERE
-            up.user_id = #{userId}
+            upb.user_id = #{userId}
 
         UNION ALL
 
-        -- 사용자가 신청한 대출 현황 조회
+        -- 사용자가 즐겨찾기한 대출 현황 조회
         SELECT
-            CONCAT('loan_', ul.user_loan_id) AS applicationId,
-            ul.status AS processStage,
+            CONCAT('loan_', ulb.bookmark_loan_id) AS applicationId,
+            ulb.status AS processStage,
             '대출' AS productType,
             l.product_name AS productName,
             l.company_name AS providerName,
             (SELECT COUNT(DISTINCT rd.document_id)
              FROM required_documents rd
-                      JOIN user_documents ud ON rd.document_id = ud.document_id
-             WHERE rd.loan_id = ul.loan_id AND ud.user_id = ul.user_id) AS completedDocsCount,
+                      JOIN user_documents ud ON rd.document_id = ud.document_id AND ud.user_id = ulb.user_id
+             WHERE rd.loan_id = ulb.loan_id) AS completedDocsCount,
             (SELECT COUNT(*)
              FROM required_documents
-             WHERE loan_id = ul.loan_id) AS totalDocsCount
+             WHERE loan_id = ulb.loan_id) AS totalDocsCount
         FROM
-            user_loans ul
+            user_loan_bookmarks ulb
                 JOIN
-            loans l ON ul.loan_id = l.loan_id
+            loans l ON ulb.loan_id = l.loan_id
         WHERE
-            ul.user_id = #{userId}
+            ulb.user_id = #{userId}
     </select>
 
     <update id="updateUserPolicyStatus">
-        UPDATE user_policies
+        UPDATE user_policy_bookmarks
         SET status = #{status}
-        WHERE user_id = #{userId} AND user_policy_id = #{id}
+        WHERE user_id = #{userId} AND bookmark_policy_id = #{id}
     </update>
 
     <update id="updateUserLoanStatus">
-        UPDATE user_loans
+        UPDATE user_loan_bookmarks
         SET status = #{status}
-        WHERE user_id = #{userId} AND user_loan_id = #{id}
+        WHERE user_id = #{userId} AND bookmark_loan_id = #{id}
     </update>
 
 </mapper>

--- a/src/main/resources/com/gagechaeum/backend/user/mapper/UserMapper.xml
+++ b/src/main/resources/com/gagechaeum/backend/user/mapper/UserMapper.xml
@@ -86,7 +86,7 @@
         SELECT EXISTS (
                    SELECT 1
                    FROM users
-                   WHERE nickname=#{nickname};
+                   WHERE nickname=#{nickname}
         )
     </select>
 


### PR DESCRIPTION
## 📑 이슈 번호
- close #49 

## ✨️ 작업 내용
- init.sql 즐겨찾기 테이블에 status추가, 사용자 정책/대출 테이블에서 status 제거
- 서류 현황 조회 API 즐겨찾기 대상으로 수정
- UserMapper.xml 세미콜론 오류 수정

## ✔️ 체크 리스트

- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] develop에서 pull을 받은 후 conflict를 처리하고 push 했는가?
- [x] 라벨을 등록했는가?
- [x] 리뷰어를 지정했는가?

## 📸 구현 결과
<img width="685" height="747" alt="image" src="https://github.com/user-attachments/assets/ed74188e-1d18-4b39-92f9-1a0a7dad49f6" />

## 💙 코멘트
