### PR TITLE
[Refactor] #101 : 리포트 API 요청 시 인증된 사용자 정보 사용하도록 수정

### DIFF
--- a/src/main/java/com/gagechaeum/backend/bookmark/dto/response/BookmarkResponseDTO.java
+++ b/src/main/java/com/gagechaeum/backend/bookmark/dto/response/BookmarkResponseDTO.java
@@ -19,4 +19,6 @@ public class BookmarkResponseDTO {
     private int progressPercentage;
     private int completedDocsCount;
     private int totalDocsCount;
+    private String policyId;
+    private Long loanId;
 }

--- a/src/main/java/com/gagechaeum/backend/report/controller/ReportController.java
+++ b/src/main/java/com/gagechaeum/backend/report/controller/ReportController.java
@@ -6,11 +6,12 @@ import com.gagechaeum.backend.report.dto.request.UserPolicyCreateRequestDTO;
 import com.gagechaeum.backend.report.dto.response.DashboardResponseDTO;
 import com.gagechaeum.backend.report.dto.response.PolicySearchResponseDTO;
 import com.gagechaeum.backend.report.service.ReportService;
-// import com.gagechaeum.backend.security.UserDetailsImpl;
+import com.gagechaeum.backend.security.account.domain.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,11 +30,10 @@ public class ReportController {
 
     @PostMapping("/policies")
     public ResponseEntity<CustomResponse<Void>> createUserPolicy(
-            // @AuthenticationPrincipal UserDetailsImpl userDetails, // 주석 해제 후 사용
+            @AuthenticationPrincipal CustomUserDetails user,
             @RequestBody UserPolicyCreateRequestDTO requestDTO
     ) {
-        // Long userId = userDetails.getUser().getId();
-        Long userId = 1L; // 테스트용 임시 사용자 ID
+        Long userId = user.getUserId();
         reportService.createUserPolicy(userId, requestDTO);
         return ResponseEntity
                 .status(ResponseCode.SUCCESS.getHttpStatus())
@@ -42,10 +42,9 @@ public class ReportController {
 
     @GetMapping("/dashboard")
     public ResponseEntity<CustomResponse<DashboardResponseDTO>> getDashboardData(
-            // @AuthenticationPrincipal UserDetailsImpl userDetails // 주석 해제 후 사용
+            @AuthenticationPrincipal CustomUserDetails user
     ) {
-        // Long userId = userDetails.getUser().getId();
-        Long userId = 1L; // 테스트용 임시 사용자 ID
+        Long userId = user.getUserId();
         DashboardResponseDTO dashboardData = reportService.getDashboardData(userId);
 
         return ResponseEntity
@@ -55,10 +54,9 @@ public class ReportController {
 
     @GetMapping("/items")
     public CustomResponse<DashboardResponseDTO.AllItemsPage> getItems(
-            // @AuthenticationPrincipal UserDetailsImpl userDetails // 주석 해제 후 사용
+            @AuthenticationPrincipal CustomUserDetails user,
             @PageableDefault(size = 5) Pageable pageable) {
-        // Long userId = userDetails.getUser().getId();
-        Long userId = 1L; // 테스트용 임시 사용자 ID
+        Long userId = user.getUserId();
         DashboardResponseDTO.AllItemsPage items = reportService.getItems(userId, pageable);
         return CustomResponse.success(ResponseCode.SUCCESS, items);
     }

--- a/src/main/java/com/gagechaeum/backend/report/dto/ReportAllItemResult.java
+++ b/src/main/java/com/gagechaeum/backend/report/dto/ReportAllItemResult.java
@@ -1,0 +1,30 @@
+package com.gagechaeum.backend.report.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class ReportAllItemResult {
+    private String type; // "POLICY" 또는 "LOAN"
+    private Long itemId;
+    private String name;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private Long amount;
+    private String amountLabel;
+
+    // LOAN 전용 필드
+    private String repaymentMethod;
+    private BigDecimal repaymentRate; // 계산은 서비스에서 수행하거나 복잡한 쿼리로 처리
+    private BigDecimal interestRate;
+
+    // POLICY 전용 필드
+    private Integer paymentDay; // 매월 지급일
+    private Long totalBenefitAmount;
+}

--- a/src/main/java/com/gagechaeum/backend/report/mapper/ReportMapper.java
+++ b/src/main/java/com/gagechaeum/backend/report/mapper/ReportMapper.java
@@ -4,8 +4,10 @@ import com.gagechaeum.backend.report.domain.PolicySearchResult;
 import com.gagechaeum.backend.report.domain.Repayment;
 import com.gagechaeum.backend.report.domain.UserLoan;
 import com.gagechaeum.backend.report.domain.UserPolicy;
+import com.gagechaeum.backend.report.dto.ReportAllItemResult;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -24,4 +26,13 @@ public interface ReportMapper {
     List<PolicySearchResult> searchPoliciesByName(@Param("keyword") String keyword);
 
     void insertUserPolicy(UserPolicy userPolicy);
+
+    // 사용자의 정책(Policy)과 대출(Loan) 정보를 합쳐서 페이징 조회
+    List<ReportAllItemResult> findCombinedItemsByUserId(
+            @Param("userId") Long userId,
+            @Param("pageable") Pageable pageable
+    );
+
+    // 사용자의 전체 정책(Policy)과 대출(Loan) 정보의 총 개수 조회
+    long countCombinedItemsByUserId(@Param("userId") Long userId);
 }

--- a/src/main/resources/com/gagechaeum/backend/bookmark/mapper/BookmarkMapper.xml
+++ b/src/main/resources/com/gagechaeum/backend/bookmark/mapper/BookmarkMapper.xml
@@ -72,6 +72,8 @@
         '대출' AS productType,
         l.product_name AS productName,
         l.company_name AS providerName,
+        NULL as policyId,
+        ulb.loan_id as loanId,
         (SELECT COUNT(DISTINCT rd.document_id)
         FROM required_documents rd
         JOIN user_documents ud ON rd.document_id = ud.document_id AND ud.user_id = ulb.user_id

--- a/src/main/resources/com/gagechaeum/backend/report/mapper/ReportMapper.xml
+++ b/src/main/resources/com/gagechaeum/backend/report/mapper/ReportMapper.xml
@@ -43,6 +43,20 @@
         <result property="policyName" column="policy_name"/>
     </resultMap>
 
+    <resultMap id="allItemResultMap" type="com.gagechaeum.backend.report.dto.ReportAllItemResult">
+        <result property="type" column="type"/>
+        <result property="itemId" column="item_id"/>
+        <result property="name" column="name"/>
+        <result property="startDate" column="start_date"/>
+        <result property="endDate" column="end_date"/>
+        <result property="amount" column="amount"/>
+        <result property="amountLabel" column="amount_label"/>
+        <result property="repaymentMethod" column="repayment_method"/>
+        <result property="interestRate" column="interest_rate"/>
+        <result property="paymentDay" column="payment_day"/>
+        <result property="totalBenefitAmount" column="total_benefit_amount"/>
+    </resultMap>
+
 
     <!-- findUserPoliciesByUserId 쿼리 -->
     <select id="findUserPoliciesByUserId" parameterType="long" resultMap="userPolicyResultMap">
@@ -115,5 +129,58 @@
          INSERT INTO user_policies (user_id, policy_id, start_date, end_date, first_payment_date, monthly_amount, total_amount)
         VALUES (#{userId}, #{policyId}, #{startDate}, #{endDate}, #{firstPaymentDate}, #{monthlyAmount}, #{totalAmount})
     </insert>
+
+    <select id="findCombinedItemsByUserId" resultMap="allItemResultMap">
+        (SELECT
+             'POLICY' AS type,
+             up.user_policy_id AS item_id,
+             p.policy_name AS name,
+             up.start_date AS start_date,
+             up.end_date AS end_date,
+             up.monthly_amount AS amount,
+             '월' AS amount_label,
+             NULL AS repayment_method,
+             NULL AS interest_rate,
+             DAY(up.first_payment_date) AS payment_day,
+             up.total_amount AS total_benefit_amount
+         FROM
+             user_policies up
+             LEFT JOIN
+             policies p ON up.policy_id = p.policy_id
+         WHERE
+             up.user_id = #{userId})
+
+        UNION ALL
+
+        (SELECT
+             'LOAN' AS type,
+             ul.user_loan_id AS item_id,
+             ul.product_name AS name,
+             ul.issue_date AS start_date,
+             ul.expiry_date AS end_date,
+             ul.balance_amount AS amount,
+             '잔액' AS amount_label,
+             ul.repay_method AS repayment_method,
+             ul.last_offered_rate AS interest_rate,
+             NULL AS payment_day,
+             NULL AS total_benefit_amount
+         FROM
+             user_loans ul
+         WHERE
+             ul.user_id = #{userId})
+
+        ORDER BY
+            start_date DESC
+            LIMIT #{pageable.pageSize} OFFSET #{pageable.offset}
+    </select>
+
+    <select id="countCombinedItemsByUserId" resultType="long">
+        SELECT SUM(total_count)
+        FROM (
+                 (SELECT COUNT(*) as total_count FROM user_policies WHERE user_id = #{userId})
+                 UNION ALL
+                 (SELECT COUNT(*) as total_count FROM user_loans WHERE user_id = #{userId})
+             ) AS combined_counts
+    </select>
 
 </mapper>


### PR DESCRIPTION
## 📑 이슈 번호
- close #101 

## ✨️ 작업 내용
- 리포트 API 요청 시 인증된 사용자 정보 사용하도록 수정
- 데이터베이스 레벨에서 페이징 처리하도록 수정
- 서류 현황 조회 api에 정책id와 대출id 불러오게 수정

## ✔️ 체크 리스트
<!-- ⚠️⚠️⚠️⚠️⚠️⚠️ 잠깐 !!!! ⚠️⚠️⚠️⚠️⚠️ -->
<!-- PR 제목 컨벤션에 맞게 잘 작성했는지, assignee 및 reviewer 지정했는지 다시 한 번 체크하기 !! -->

- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] develop에서 pull을 받은 후 conflict를 처리하고 push 했는가?
- [x] 라벨을 등록했는가?
- [x] 리뷰어를 지정했는가?

## 📸 구현 결과
### 서류 현황 조회 api 수정
<img width="617" height="749" alt="image" src="https://github.com/user-attachments/assets/d8df47a6-8734-49e5-b76f-93587945f465" />

## 💙 코멘트
