### PR TITLE
[Fix] 정책 지역/업종코드 매핑, 닉네임 검증 오류 수정 및 테스트 완료

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -102,7 +102,7 @@ CREATE TABLE policy_details_temp
         primary key,
     raw_text   text                                null,
     updated_at timestamp default CURRENT_TIMESTAMP not null on update CURRENT_TIMESTAMP
-)
+);
 
 
 CREATE TABLE policy_bookmark_counts (

--- a/src/main/java/com/gagechaeum/backend/policy/dto/external/Gov24ApiServiceDto.java
+++ b/src/main/java/com/gagechaeum/backend/policy/dto/external/Gov24ApiServiceDto.java
@@ -55,4 +55,7 @@ public class Gov24ApiServiceDto {
 
     @JsonProperty("소관기관명")
     private String organizationName;
+
+    @JsonProperty("지원유형")
+    private String supportType;
 }

--- a/src/main/java/com/gagechaeum/backend/policy/service/PolicyMatchingServiceImpl.java
+++ b/src/main/java/com/gagechaeum/backend/policy/service/PolicyMatchingServiceImpl.java
@@ -69,6 +69,7 @@ public class PolicyMatchingServiceImpl implements PolicyMatchingService {
         }
 
         List<Policy> policiesToMatch = policyMapper.findPoliciesForMatching();
+
         if (policiesToMatch.isEmpty()) {
             log.info("새롭게 매칭할 정책이 없습니다. 프로세스를 종료합니다.");
             return;
@@ -76,10 +77,9 @@ public class PolicyMatchingServiceImpl implements PolicyMatchingService {
 
         log.info("총 {}개의 정책에 대해 매칭을 시작합니다.", policiesToMatch.size());
         for (Policy policy : policiesToMatch) {
-            String policyText = buildPolicyTextForMatching(policy);
 
-            Long regionId = findRegionId(policyText);
-            Long industryId = findIndustryId(policyText);
+            Long regionId = findRegionId(policy);
+            Long industryId = findIndustryId(policy);
 
             // 미분류 지역은 전국으로 설정
             if (regionId == null) {
@@ -103,25 +103,38 @@ public class PolicyMatchingServiceImpl implements PolicyMatchingService {
         );
     }
 
-    private Long findRegionId(String policyText) {
+    private Long findRegionId(Policy policy) {
+        String organizationName = policy.getSupervisingOrganizationName();
+        if (organizationName == null || organizationName.isBlank()) {
+            return null;
+        }
+
         return regionCacheForMatching.stream()
-                .filter(region -> policyText.contains(region.getFullName()))
+                .filter(region -> organizationName.contains(region.getFullName()))
                 .map(Regions::getRegionId)
                 .findFirst()
                 .orElse(null);
     }
 
-    private Long findIndustryId(String policyText) {
+    private Long findIndustryId(Policy policy) {
+        // 업종 분석을 위해 더 많은 텍스트 정보를 조합
+        String policyTextForIndustry = String.join(" ",
+                policy.getPolicyName(),
+                policy.getSupportTarget(),
+                policy.getPolicySummary(),
+                policy.getSupportDetail()
+        );
 
         return industryCacheForMatching.stream()
-
                 .filter(industry -> {
-                    boolean nameMatches = policyText.contains(industry.getName());
+                    // 1. 업종 이름이 직접 포함되어 있는지 확인
+                    boolean nameMatches = policyTextForIndustry.contains(industry.getName());
                     if (nameMatches) return true;
 
+                    // 2. 업종 관련 키워드가 포함되어 있는지 확인
                     if (industry.getKeywords() != null && !industry.getKeywords().isBlank()) {
                         return Arrays.stream(industry.getKeywords().split(","))
-                                .anyMatch(keyword -> policyText.contains(keyword.trim()));
+                                .anyMatch(keyword -> policyTextForIndustry.contains(keyword.trim()));
                     }
                     return false;
                 })

--- a/src/main/java/com/gagechaeum/backend/policy/service/PolicySyncServiceImpl.java
+++ b/src/main/java/com/gagechaeum/backend/policy/service/PolicySyncServiceImpl.java
@@ -10,7 +10,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -27,6 +26,8 @@ public class PolicySyncServiceImpl implements PolicySyncService {
     private final Gov24ApiClient gov24ApiClient;
     private final PolicyMapper policyMapper;
     private final PolicyMatchingService policyMatchingService;
+    private static final String TARGET_USER_TYPE = "소상공인";
+    private static final String TARGET_SUPPORT_TYPE = "현금";
 
     private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmss");
 
@@ -47,6 +48,7 @@ public class PolicySyncServiceImpl implements PolicySyncService {
         int page = 1;
         int perPage = 30;
 
+
         List<Policy> existingPolicies = policyMapper.findAllPolicyIdsWithModificationDate();
         Map<String, LocalDateTime> existingMap = existingPolicies.stream()
                 .filter(p -> p.getPolicyId() != null)
@@ -62,6 +64,13 @@ public class PolicySyncServiceImpl implements PolicySyncService {
             log.info("{} 페이지에서 {}개의 정책을 처리합니다.", page, apiResponse.getCurrentCount());
 
             for (Gov24ApiServiceDto dto : apiResponse.getData()) {
+                if (!isSmallBusinessCashSupportPolicy(dto)) {
+                    log.trace("소상공인 대상 현금 지원 정책이 아니므로 건너<binary data, 2 bytes>니다 (policyName: {}, userType: {}, supportType: {})",
+                            dto.getServiceName(), dto.getUserType(), dto.getSupportContent());
+                    continue; // 조건에 맞지 않으면 다음 정책으로 넘어감
+                }
+
+
                 Policy policy = mapDtoToDomain(dto);
                 LocalDateTime existingDate = existingMap.get(policy.getPolicyId());
                 boolean needsUpdate = (existingDate == null) ||
@@ -70,12 +79,19 @@ public class PolicySyncServiceImpl implements PolicySyncService {
 
                 if (needsUpdate) {
                     policyMapper.saveOrUpdatePolicy(policy);
-                    log.debug("정책 기본 정보 저장 완료 (policyId: {})", policy.getPolicyId());
+                    log.debug("소상공인 지원금 정책 정보 저장 완료 (policyId: {})", policy.getPolicyId());
                 }
             }
             page++;
         } while (true);
         log.info("정책 기본 정보 동기화가 완료되었습니다.");
+    }
+
+    private boolean isSmallBusinessCashSupportPolicy(Gov24ApiServiceDto dto) {
+        boolean isTargetUser = dto.getUserType() != null && dto.getUserType().contains(TARGET_USER_TYPE);
+        boolean isTargetSupport = TARGET_SUPPORT_TYPE.equals(dto.getSupportType());
+        // '소상공인'이면서 '현금' 지원 정책이어야 함 (AND 조건)
+        return isTargetUser && isTargetSupport;
     }
 
     private Policy mapDtoToDomain(Gov24ApiServiceDto dto) {

--- a/src/main/java/com/gagechaeum/backend/user/controller/UserController.java
+++ b/src/main/java/com/gagechaeum/backend/user/controller/UserController.java
@@ -131,7 +131,7 @@ public class UserController {
 
     @PutMapping("/update/user")
     public ResponseEntity<CustomResponse<Void>> update(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody UpdateUserDTO req) {
-        userService.updateUser(userDetails.getUserId(), req);
+        userService.updateUser(userDetails, req);
         return ResponseEntity
                 .status(ResponseCode.UPDATE_USER_SUCCESS.getHttpStatus())
                 .body(CustomResponse.success(ResponseCode.UPDATE_USER_SUCCESS));

--- a/src/main/java/com/gagechaeum/backend/user/service/UserService.java
+++ b/src/main/java/com/gagechaeum/backend/user/service/UserService.java
@@ -19,7 +19,7 @@ public interface UserService {
     void logout(String token);
     void withdrawal(String token);
     void updateNotification(Long id, Boolean notification);
-    void updateUser(Long id, UpdateUserDTO req);
+    void updateUser(CustomUserDetails userDetails, UpdateUserDTO req);
     UserInfoResponseDTO getUserInfo(CustomUserDetails user);
     Boolean passwordVerify(CustomUserDetails user, String password);
 

--- a/src/main/java/com/gagechaeum/backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/gagechaeum/backend/user/service/UserServiceImpl.java
@@ -381,7 +381,6 @@ public class UserServiceImpl implements UserService {
     }
 
     public Boolean passwordVerify(CustomUserDetails userDetails, String password) {
-
         if (userDetails == null) {
             throw new UserNotFoundException();
         }

--- a/src/main/java/com/gagechaeum/backend/user/service/UserServiceImpl.java
+++ b/src/main/java/com/gagechaeum/backend/user/service/UserServiceImpl.java
@@ -313,10 +313,15 @@ public class UserServiceImpl implements UserService {
         log.info("알림여부 변경완료 : {}", notification);
     }
 
-    public void updateUser(Long id, UpdateUserDTO req) {
+    public void updateUser(CustomUserDetails userDetails, UpdateUserDTO req) {
 
-        isNicknameExist(req.getNickname());
-        userMapper.updateUser(id, req);
+        String oldNickname=userDetails.getNickname();
+
+        if (!oldNickname.equals(req.getNickname())) {
+            isNicknameExist(req.getNickname());
+        }
+
+        userMapper.updateUser(userDetails.getUserId(), req);
         log.info("유저정보 변경완료 : {}", req.toString());
     }
 
@@ -376,6 +381,7 @@ public class UserServiceImpl implements UserService {
     }
 
     public Boolean passwordVerify(CustomUserDetails userDetails, String password) {
+
         if (userDetails == null) {
             throw new UserNotFoundException();
         }


### PR DESCRIPTION
## 📑 이슈 번호
- close #99 

## ✨️ 작업 내용
1. 정책 동기화 시, 소상공인 대상의 지원금 정책만 DB에 저장하도록 만들었습니다.(userType컬럼에서 소상공인인 것만 필터링, 지원유형에서 '현금'이 포함된 것만 필터링)
2. 지역코드는 법정동 정보과 정책정보의 관할부처값을 비교하여 매칭하도록 조치
3. 업종코드는 기존 업종코드들을, 정책명+정책요약+정책설명들과 비교하여 매칭하도록 조치
4. 닉네임 업데이트 오류를 수정했습니다.(유저정보 수정 시, 닉네임이 같은 경우에는 닉네임 중복 메서드 실행X하도록 변경)

## ✔️ 체크 리스트
- [x] Merge 하려는 브랜치가 올바른가? (`main` branch에 실수로 PR 생성 금지)
- [x] Merge 하려는 PR 및 Commit들을 **로컬**에서 실행했을 때 에러가 발생하지 않았는가?
- [x] develop에서 pull을 받은 후 conflict를 처리하고 push 했는가?
- [x] 라벨을 등록했는가?
- [x] 리뷰어를 지정했는가?

## 📸 구현 결과
<img width="280" height="177" alt="image" src="https://github.com/user-attachments/assets/7b7ea064-6314-4ada-b54f-7396d9aebf51" />
필터링 전에는 8000개 가량 되는 데이터가, 103개정도로 필터링되었습니다. 모두 소상공인 대상의 지원금정책

## 💙 코멘트
